### PR TITLE
Fix loader code

### DIFF
--- a/cryptomon.py
+++ b/cryptomon.py
@@ -39,7 +39,9 @@ def parse_argz():
     parser.add_argument("--pcap",
                         help="PCAP file to be replayed on loopback.")
     parser.add_argument("-tc", "--traffic-control",
+                        dest='traffic_control', action='store_true',
                         help="Use TC to manipulate interfaces - Use for passive network SPAN/TAP data over an ethernet port.")
+    parser.set_defaults(traffic_control=False)
     args = parser.parse_args()
 
     if not args.interface:

--- a/cryptomon.py
+++ b/cryptomon.py
@@ -38,7 +38,7 @@ def parse_argz():
                         help="Interface to hook with eBPF module.")
     parser.add_argument("--pcap",
                         help="PCAP file to be replayed on loopback.")
-    parser.add_argument("--traffic-control",
+    parser.add_argument("-tc", "--traffic-control",
                         help="Use TC to manipulate interfaces - Use for passive network SPAN/TAP data over an ethernet port.")
     args = parser.parse_args()
 

--- a/cryptomon.py
+++ b/cryptomon.py
@@ -34,10 +34,12 @@ def list_interfaces():
 
 def parse_argz():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--interface", 
+    parser.add_argument("-i", "--interface",
                         help="Interface to hook with eBPF module.")
-    parser.add_argument("--pcap", 
+    parser.add_argument("--pcap",
                         help="PCAP file to be replayed on loopback.")
+    parser.add_argument("--traffic-control",
+                        help="Use TC to manipulate interfaces - Use for passive network SPAN/TAP data over an ethernet port.")
     args = parser.parse_args()
 
     if not args.interface:
@@ -75,11 +77,16 @@ if __name__ == "__main__":
     if args.pcap:
         rerun_pcap(args.pcap)
         sys.exit(0)
+    if args.traffic_control:
+        lm = "TC"
+    else:
+        lm = "library"
     cm = CryptoMon(iface=args.interface,
                    mongodb=True,
                    settings=settings,
                    pcap_file=args.pcap,
-                   data_tag="")
+                   data_tag="",
+                   load_method=lm)
     loop = asyncio.get_event_loop()
     loop.create_task(cm.run_async())
     loop.run_forever()

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -43,7 +43,7 @@ class CryptoMon(object):
         self.data_tag = data_tag if data_tag else ""
         self.b = BPF(text=bpf_code)
         self.unload_tc_device = False
-        if load_method != "TC":  # don't use Traffic Control to manage devices
+        if load_method == "library":  # don't use Traffic Control to manage devices
             # old code
             self.fn = self.b.load_func("crypto_monitor", BPF.SOCKET_FILTER)
             BPF.attach_raw_socket(self.fn, iface)
@@ -63,7 +63,7 @@ class CryptoMon(object):
             # NB - the TC documentation doesn't say much about clsact yet.
             # The best ref is still: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1f211a1b929c804100e138c5d3d656992cfd5622
             self.ipr.tc("add-filter", "bpf", self.if_name, ":1", fd=self.fn.fd,
-                        name=self.fn.name, parent="ffff:fff2",
+                        name=self.fn.name, parent="ffff:fff2", # parent can be :fff2 for ingress or :fff3 for egress. 
                         classid=1, direct_action=True)
         self.b["skb_events"].open_perf_buffer(self.get_ebpf_data)
         self.fapi_on = False

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -61,7 +61,7 @@ class CryptoMon(object):
             except:
                 print("[i] 'add clsact' failed on interface, but may well work fine.")
             self.ipr.tc("add-filter", "bpf", self.if_name, ":1", fd=self.fn.fd,
-                        name=self.fn.name, parent="ffff:fff3",
+                        name=self.fn.name, parent="ffff:fff1",
                         classid=1, direct_action=True)
         self.b["skb_events"].open_perf_buffer(self.get_ebpf_data)
         self.fapi_on = False

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -43,7 +43,7 @@ class CryptoMon(object):
         self.data_tag = data_tag if data_tag else ""
         self.b = BPF(text=bpf_code)
         self.unload_tc_device = False
-        if load_method != "TC": # don't use Traffic Control to manage devices
+        if load_method != "TC":  # don't use Traffic Control to manage devices
             # old code
             self.fn = self.b.load_func("crypto_monitor", BPF.SOCKET_FILTER)
             BPF.attach_raw_socket(self.fn, iface)
@@ -60,6 +60,8 @@ class CryptoMon(object):
                 self.ipr.tc("add", "clsact", self.if_name)  # add qdisc clsact.
             except:
                 print("[i] 'add clsact' failed on interface, but may work fine...")
+            # NB - the TC documentation doesn't say much about clsact yet.
+            # The best ref is still: https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1f211a1b929c804100e138c5d3d656992cfd5622
             self.ipr.tc("add-filter", "bpf", self.if_name, ":1", fd=self.fn.fd,
                         name=self.fn.name, parent="ffff:fff2",
                         classid=1, direct_action=True)

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -56,7 +56,10 @@ class CryptoMon(object):
             self.if_name = self.ipr.link_lookup(ifname=iface)[0]
             self.ipr.link('set', index=self.if_name, state='up')
             self.ipr.link('set', index=self.if_name, flags=['IFF_PROMISC'])  # set PROMISC mode...
-            # self.ipr.tc("add", "clsact", self.if_name)  # add qdisc; udpate - not needed! causes errrors. TOFIX.
+            try:
+                self.ipr.tc("add", "clsact", self.if_name)  # add qdisc; udpate - not needed! causes errrors. TOFIX.
+            except:
+                print("[i] 'add clsact' failed on interface, but may well work fine.")
             self.ipr.tc("add-filter", "bpf", self.if_name, ":1", fd=self.fn.fd,
                         name=self.fn.name, parent="ffff:fff3",
                         classid=1, direct_action=True)

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -57,11 +57,11 @@ class CryptoMon(object):
             self.ipr.link('set', index=self.if_name, state='up')
             self.ipr.link('set', index=self.if_name, flags=['IFF_PROMISC'])  # set PROMISC mode...
             try:
-                self.ipr.tc("add", "clsact", self.if_name)  # add qdisc; udpate - not needed! causes errrors. TOFIX.
+                self.ipr.tc("add", "clsact", self.if_name)  # add qdisc clsact.
             except:
-                print("[i] 'add clsact' failed on interface, but may well work fine.")
+                print("[i] 'add clsact' failed on interface, but may work fine...")
             self.ipr.tc("add-filter", "bpf", self.if_name, ":1", fd=self.fn.fd,
-                        name=self.fn.name, parent="ffff:fff1",
+                        name=self.fn.name, parent="ffff:fff2",
                         classid=1, direct_action=True)
         self.b["skb_events"].open_perf_buffer(self.get_ebpf_data)
         self.fapi_on = False

--- a/cryptomon/__init__.py
+++ b/cryptomon/__init__.py
@@ -37,7 +37,7 @@ class CryptoMon(object):
     def __init__(self, iface="enp0s1", fapiapp: FastAPI = "",
                  mongodb=False, settings="",
                  bpf_code=bpf_ipv4_txt, pcap_file="",
-                 data_tag="", load_method="TC"):
+                 data_tag="", load_method="library"):
         if not settings:
             raise Exception("No settings provided... Aborting.")
         self.data_tag = data_tag if data_tag else ""


### PR DESCRIPTION
Setups up various options for loading the BPF module into an interface:

1. Use the build-in loader from `bcc` - useful when monitoring an API's traffic from the box.
2. Use the traffic controls in `pyroute2` - useful when monitoring, say, SPAN/TAP traffic on an ethernet port.